### PR TITLE
Update string of result for polynomial func.

### DIFF
--- a/src/regression.js
+++ b/src/regression.js
@@ -185,7 +185,7 @@
                     var string = 'y = ';
 
                     for(var i = equation.length-1; i >= 0; i--){
-                      if(i > 1) string += Math.round(equation[i]*100) / 100 + 'x^' + i + ' + ';
+                      if(i > 1) string += Math.round(equation[i] * Math.pow(10, i)) / Math.pow(10, i)  + 'x^' + i + ' + ';
                       else if (i == 1) string += Math.round(equation[i]*100) / 100 + 'x' + ' + ';
                       else string += Math.round(equation[i]*100) / 100;
                     }


### PR DESCRIPTION
Now string starts with 0 for polynomial >2 order. 
E.g. 
`y = -0x^4 + -0.01x^3 + -0.03x^2 + -1.64x + 30.67` 
or `string: "y = -0x^3 + -0.04x^2 + -1.71x + 30.65"`

PR fixs this (string: "y = **-0.002x^3** + -0.04x^2 + -1.71x + 30.65")

p.s. In any case, I want to thank you for the wonderful library.