### PR TITLE
Adds support for lib execution in web worker threads

### DIFF
--- a/src/regression.js
+++ b/src/regression.js
@@ -9,7 +9,7 @@
 *
 **/
 
-;(function() {
+;(function(ns) {
     'use strict';
 
     var gaussianElimination = function(a, o) {
@@ -242,7 +242,7 @@ var regression = (function(method, data, order) {
 if (typeof exports !== 'undefined') {
     module.exports = regression;
 } else {
-    window.regression = regression;
+    ns.regression = regression;
 }
 
-}());
+}(this));


### PR DESCRIPTION
Deletes the reference to `window`, which prevented the library from running in a web worker thread.