### PR TITLE
remove .babelrc from npm published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .git*
 example/
 .DS_Store
+.babelrc


### PR DESCRIPTION
`regression-js` already publishes the transpiled`dist` folder to npm, so there is no need to publish the `.babelrc` file.

Doing so causes `babel-jest` to fail, because it traverses `node_modules` for `.babelrc` files, and then fails if the babel plugins and presets in the `.babelrc` file cannot be found in the consuming repo's `node_modules` directory.

Npm ignoring the `.babelrc` file resolves the issue that would otherwise require a consumer to always have the following packages installed if they wish to use `babel-jest`:

`babel-preset-es2015`
`babel-preset-stage-0`
`babel-plugin-transform-es2015-modules-umd`